### PR TITLE
Fix view.context reactivity by reverting to original implementation

### DIFF
--- a/modules/view/src/nextjournal/view/context.cljs
+++ b/modules/view/src/nextjournal/view/context.cljs
@@ -9,9 +9,6 @@
   example use:
 
   ``` clojure
-  ;; Optional, provide a fallback when no c/provide is available in the render tree.
-  (c/set-default :app-theme {:color \"red\"})
-
   [c/provide {:app-theme {:color \"blue\"}}
    ;; consume one context at a time
    [c/consume :app-theme
@@ -24,32 +21,16 @@
             [reagent.core :as reagent]
             [nextjournal.log :as log]))
 
-(defonce contexts (atom {}))
-
-(defn set-default
-  "Set the default value for a given context, identified by keyword.
-
-  This should only be called at the top level, before rendering, since it will
-  replace any existing context with the same key."
-  [context-key default-value]
-  (swap! contexts
-         (fn [cs]
-           (when (get cs context-key)
-             (log/warn :replacing-context {:context-key context-key
-                                           :default-value default-value}))
-           (assoc cs context-key (react/createContext default-value)))))
-
-(defn get-context [context-or-key]
-  (if (keyword? context-or-key)
-    (or (get @contexts context-or-key)
-        (do
-          (set-default context-or-key nil)
-          (get @contexts context-or-key)))
-    context-or-key))
+(defonce get-context
+  (memoize
+   (fn [k]
+     (if (keyword? k)
+       (react/createContext (munge (str k)))
+       k))))
 
 (defn provide
   "Adds React contexts to the component tree.
-  `bindings` should be a map of {<keyword-or-Context>, <value-to-be-bound>}."
+   `bindings` should be a map of {<keyword-or-Context>, <value-to-be-bound>}."
   [bindings & body]
   (loop [bindings (seq bindings)
          out (->> body
@@ -67,29 +48,10 @@
 
 (defn consume
   "Reads a React context value within component tree.
-  `context` should be a keyword or React Context instance."
+   `context` should be a keyword or React Context instance."
   [context f]
-  ;; This is a weird hack, but apparently there's no really obvious better way
-  ;; to address this. The issue is that `f` is typically defined inline, it's
-  ;; probably closing over some values, so it's going to be a different function
-  ;; on every invocation/render. If we use it directly as a reagent component
-  ;; like [f value] then reagent/react will treat it as a different component
-  ;; type on every render, and won't reuse any DOM elements beneath it in the
-  ;; tree. This is most apparent with things like mapbox where it really matters
-  ;; that we don't draw a new map on every render. But if we instead call the
-  ;; passed in function directly instead of treating it like a component, then
-  ;; we lose reactivity, i.e. changing reagent atoms which are (de)referenced in
-  ;; the function won't cause the component to re-render. The work around is to
-  ;; create a "static" wrapper component (`wrapper`) with `with-let` so to React
-  ;; it looks like it's always the same component, and we have a component to
-  ;; stick in Hiccup and get reactivity. Then in there we call the most recent
-  ;; `f` to do the actual rendering. Doesn't look great but it does all it needs
-  ;; to do.
-  (reagent/with-let [box (atom f)
-                     wrapper (fn [& args]
-                               (apply @box args))]
-    (react/createElement (.-Consumer (get-context context))
-                         #js {}
-                         (fn [value]
-                           (reset! box f)
-                           (reagent/as-element [wrapper value])))))
+  (react/createElement
+   (.-Consumer (get-context context))
+   #js {}
+   (fn [value]
+     (reagent/as-element [f value]))))


### PR DESCRIPTION
Reactivity is broken in the old implementation so I've reverted to the original one.

I need this in Clerk now but we'll need to check our usage of downstream consumers to ensure they don't rely on `set-default` or have performance regressions before me upgrade them.