### PR TITLE
MS-Windows: fix markdown.mjs path issue

### DIFF
--- a/modules/devdocs/deps.edn
+++ b/modules/devdocs/deps.edn
@@ -6,7 +6,7 @@
         io.github.nextjournal/cljs-extensions {:local/root "../cljs-extensions"}
         io.github.nextjournal/markdown {:local/root "../markdown"}
 
-        com.nextjournal/clerk {:git/url "git@github.com:nextjournal/clerk.git"
+        com.nextjournal/clerk {:git/url "https://github.com/nextjournal/clerk.git"
                                :git/sha "d2cacf6d3d27768f34b9092c100be9083c6dd1fc"}
 
         ;; we use shadow-resource directly

--- a/modules/markdown/src/nextjournal/markdown.clj
+++ b/modules/markdown/src/nextjournal/markdown.clj
@@ -25,7 +25,7 @@
 
 (def ^Value MD-imports
   (.eval ctx (.build (Source/newBuilder "js"
-                                        (str "import MD from '" (.getPath (io/resource "js/markdown.mjs")) "'; MD")
+                                        (str "import MD from '" (io/resource "js/markdown.mjs") "'; MD")
                                         "source.mjs"))))
 
 (defn make-js-fn [fn-name]


### PR DESCRIPTION
Hi,

could you please consider fix for markdown and `git:/` issues described in #29.

The markdown fix is to include the URL path verbatim in the js import (otherwise the path is invalid, because it starts with a leading slash, e.g. `/C:/...`).

The fix for the clerk dependency issue is to switch from `git:/` to `https:/` . The `git` protocol can be more demanding than `https`. The initial error I had encountered was with `clojure` cli tool trying to checkout `clerk` using the `git` protocol by calling the `git` command line tool. The latter calls `ssh` to instrument the download. On MS-Windows `putty link ` is used as a replacement for `ssh`, and it might block waiting for user to confirm the server's fingerprint when first encountering a remote git server it does not know about. If bootstrapping from a IDE such as Cider, the message might not come through to the user, "freezing" the whole process without feedback. Suggestion thus is to switch to `https:/`, which is less demanding and should work in most cases without an issue.

Thanks.