### PR TITLE
Fix for loading markdown.mjs on MS-Windows

### DIFF
--- a/modules/markdown/src/nextjournal/markdown.clj
+++ b/modules/markdown/src/nextjournal/markdown.clj
@@ -25,7 +25,7 @@
 
 (def ^Value MD-imports
   (.. ctx
-      (eval (.build (Source/newBuilder "js" (io/resource "js/markdown.mjs"))))
+      (eval (.build (Source/newBuilder "js" (io/file (io/resource "js/markdown.mjs")))))
       (getMember "default")))
 
 (defn make-js-fn [fn-name]


### PR DESCRIPTION
Hi,

could you please consider work around for #29 about loading markdown.mjs on MS-Windows, which is still occurring even after the #31 cumulative patch.

The cause of the issue seems to be with [oracle/graaljs](https://github.com/oracle/graaljs) this time though. It appears as if it tries to use the path component of the  Source URL as a path to he resource, but this method does not seem to be working on MS-Windows because the path component begins with `/`, and not a drive letter as common windows paths. I've raised https://github.com/oracle/graaljs/issues/534 so as to get some feedback.

The work around is to warp the resource in a `File`. I've tested this to work both on MS-Windows and Linux, but not sure how to test using the more involved jar example mentioned in #31.

Thanks

