### PR TITLE
Fix markdown.mjs issue not loading on MS-Windows (w jar supp)

### DIFF
--- a/modules/markdown/src/nextjournal/markdown.clj
+++ b/modules/markdown/src/nextjournal/markdown.clj
@@ -24,9 +24,13 @@
 (def ^Context ctx (.build context-builder))
 
 (def ^Value MD-imports
-  (.. ctx
-      (eval (.build (Source/newBuilder "js" (io/resource "js/markdown.mjs"))))
-      (getMember "default")))
+  (let [source (-> (io/resource "js/markdown.mjs")
+                   io/input-stream
+                   java.io.InputStreamReader.
+                   (as-> r (Source/newBuilder "js" ^java.io.Reader r "markdown.mjs")))]
+    (.. ctx
+        (eval (.build source))
+        (getMember "default"))))
 
 (defn make-js-fn [fn-name]
   (let [f (.getMember MD-imports fn-name)]

--- a/modules/markdown/src/nextjournal/markdown.clj
+++ b/modules/markdown/src/nextjournal/markdown.clj
@@ -4,7 +4,7 @@
             [clojure.data.json :as json]
             [nextjournal.markdown.parser :as markdown.parser]
             [nextjournal.markdown.transform :as markdown.transform])
-  (:import [org.graalvm.polyglot Context Context$Builder Source Value]))
+  (:import (org.graalvm.polyglot Context Context$Builder Source Value)))
 
 (set! *warn-on-reflection* true)
 
@@ -24,9 +24,11 @@
 (def ^Context ctx (.build context-builder))
 
 (def ^Value MD-imports
+  ;; Contructing a `java.io.Reader` first to work around a bug with graal on windows
+  ;; see https://github.com/oracle/graaljs/issues/534 and https://github.com/nextjournal/viewers/pull/33
   (let [source (-> (io/resource "js/markdown.mjs")
                    io/input-stream
-                   java.io.InputStreamReader.
+                   io/reader
                    (as-> r (Source/newBuilder "js" ^java.io.Reader r "markdown.mjs")))]
     (.. ctx
         (eval (.build source))


### PR DESCRIPTION
Hi,

could you please consider a follow up attempt to #32 to fix the loading of the markdown module under windows as described in #29. 

With this workaround, we are simply switching the loading Source method from URL to java Reader ([doc](https://www.graalvm.org/sdk/javadoc/org/graalvm/polyglot/Source.Builder.html)), and thus utilising core java functions for reading the file rather than delegating to `graal.js` and failing due to a suspected bug (https://github.com/oracle/graaljs/issues/534) .

I've tested it to work even when the module is embedded in an external jar file (as per the recent methodology used by Clerk).

Tests run:

1. The viewer's `clojure -X:test/markdown`, and
2. Clerk's `bb dev` environment, with the page viewable on `http://localhost:7778`.

Thanks
