### PR TITLE
Simplify Markdown TOC Data

### DIFF
--- a/modules/devcards/src/nextjournal/devcards_ui.cljs
+++ b/modules/devcards/src/nextjournal/devcards_ui.cljs
@@ -179,7 +179,7 @@
       frame
       (let [data (when data (data))]
         (log/trace :devcards/show-card {:card card :frame-id (:frame-id (rf/current-frame))})
-        [:div.not-prose
+        [:div
          (if (fn? data)
            ;; `compile-key` is used to force a re-mount of show-card*
            ;; when the _literal code_ for the card's data has changed.

--- a/modules/markdown/src/nextjournal/markdown/parser.cljc
+++ b/modules/markdown/src/nextjournal/markdown/parser.cljc
@@ -135,39 +135,44 @@
 (defn into-toc [toc {:as toc-item :keys [heading-level]}]
   (loop [toc toc l heading-level toc-path [:children]]
     ;; `toc-path` is `[:children i₁ :children i₂ ... :children]`
-    (cond
-      ;; insert intermediate default empty :children collections for the final update-in (which defaults to maps otherwise)
-      (not (get-in toc toc-path))
-      (recur (assoc-in toc toc-path []) l toc-path)
+    (let [type-path (assoc toc-path (dec (count toc-path)) :type)]
+      (cond
+        ;; insert intermediate default empty :content collections for the final update-in (which defaults to maps otherwise)
+        (not (get-in toc toc-path))
+        (recur (assoc-in toc toc-path []) l toc-path)
 
-      (= 1 l)
-      (update-in toc toc-path (fnil conj []) toc-item)
+        ;; fill in toc types for non-contiguous jumps like h1 -> h3
+        (not (get-in toc type-path))
+        (recur (assoc-in toc type-path :toc) l toc-path)
 
-      :else
-      (recur toc
-             (dec l)
-             (conj toc-path
-                   (max 0 (dec (count (get-in toc toc-path)))) ;; select last child at level if it exists
-                   :children)))))
+        (= 1 l)
+        (update-in toc toc-path (fnil conj []) toc-item)
 
-(defn add-to-toc [{:as doc ::keys [path]}]
+        :else
+        (recur toc
+               (dec l)
+               (conj toc-path
+                     (max 0 (dec (count (get-in toc toc-path)))) ;; select last child at level if it exists
+                     :children))))))
+
+(defn add-to-toc [{:as doc :keys [toc] path ::path}]
   (let [{:as h :keys [heading-level]} (get-in doc path)]
     (cond-> doc
       (pos-int? heading-level)
-      (update :toc into-toc (-> h
-                                (dissoc :type)
-                                (assoc :title (md.transform/->text h)
-                                       :path path))))))
+      (update :toc into-toc (assoc h
+                                   :type :toc
+                                   :title (md.transform/->text h)
+                                   :path path)))))
 
 (defn set-title-when-missing [{:as doc :keys [title] ::keys [path]}]
   (cond-> doc (nil? title) (assoc :title (md.transform/->text (get-in doc path)))))
 
 (comment
  (-> {:type :toc}
-     (into-toc {:heading-level 3 :title "Foo"})
+     ;;(into-toc {:heading-level 3 :title "Foo"})
      ;;(into-toc {:heading-level 2 :title "Section 1"})
-     (into-toc {:heading-level 1 :title "Title"})
-     (into-toc {:heading-level 3 :title "Section 2"})
+     (into-toc {:heading-level 1 :title "Title" :type :toc})
+     (into-toc {:heading-level 4 :title "Section 2" :type :toc})
      ;;(into-toc {:heading-level 4 :title "Section 2.1"})
      ;;(into-toc {:heading-level 2 :title "Section 3"})
      )

--- a/modules/markdown/src/nextjournal/markdown/parser.cljc
+++ b/modules/markdown/src/nextjournal/markdown/parser.cljc
@@ -159,6 +159,9 @@
                                 (assoc :title (md.transform/->text h)
                                        :path path))))))
 
+(defn set-title-when-missing [{:as doc :keys [title] ::keys [path]}]
+  (cond-> doc (nil? title) (assoc :title (md.transform/->text (get-in doc path)))))
+
 (comment
  (-> {:type :toc}
      (into-toc {:heading-level 3 :title "Foo"})
@@ -209,7 +212,7 @@ end"
 
 ;; blocks
 (defmethod apply-token "heading_open" [doc token] (open-node doc :heading {} {:heading-level (hlevel token)}))
-(defmethod apply-token "heading_close" [doc {doc-level :level}] (-> doc close-node (cond-> (zero? doc-level) add-to-toc)))
+(defmethod apply-token "heading_close" [doc {doc-level :level}] (-> doc close-node (cond-> (zero? doc-level) (-> add-to-toc set-title-when-missing))))
 ;; for building the TOC we just care about headings at document top level (not e.g. nested under lists) ⬆
 
 (defmethod apply-token "paragraph_open" [doc _token] (open-node doc :paragraph))

--- a/modules/markdown/src/nextjournal/markdown/transform.cljc
+++ b/modules/markdown/src/nextjournal/markdown/transform.cljc
@@ -31,25 +31,35 @@
                         (keep (partial ->hiccup (assoc ctx ::parent node)))
                         content)))
 
-(defn toc->hiccup [{:as ctx ::keys [parent]} {:as node heading :node :keys [content]}]
-  (cond->> [:div
-            (when heading
-              [:a {:href (str "#" (-> heading ->text ->id))
-                   #?@(:cljs [:on-click (fn [event]
-                                          (when-let [a (.. event -target (closest ".toc a"))]
-                                            (let [id (.. a (getAttribute "href") (substr 1))]
-                                              (when-let [el (.getElementById js/document id)]
-                                                (.preventDefault event)
-                                                (.scrollIntoViewIfNeeded el)))))])}
-               (-> heading heading-markup (into-markup ctx heading))])
-            (when (seq content)
-              (into [:ul]
-                (map (partial ->hiccup (assoc ctx ::parent node)))
-                content))]
-    (= :toc (:type parent))
-    (conj [:li.toc-item])
-    (not= :toc (:type parent))
-    (conj [:div.toc])))
+(defn toc->hiccup [{:as ctx ::keys [parent]} {:as node :keys [title children]}]
+  (let [toc-item (cond-> [:div]
+                   title
+                   (conj (let [id (->id title)]
+                           [:a {:href (str "#" id) #?@(:cljs [:on-click #(when-some [el (.getElementById js/document id)] (.preventDefault %) (.scrollIntoViewIfNeeded el))])}
+                            (-> node heading-markup (into-markup ctx node))]))
+                   (seq children)
+                   (conj (into [:ul] (keep (partial toc->hiccup (assoc ctx ::parent node))) children)))]
+    (cond->> toc-item
+      (= :toc (:type parent))
+      (conj [:li.toc-item])
+      (not= :toc (:type parent))
+      (conj [:div.toc]))))
+
+(comment
+  ;; override toc rendering
+  (-> "# Hello
+a paragraph
+[[TOC]]
+## Section _nice_ One
+### Section Nested
+## Section **terrible** Idea
+"
+      nextjournal.markdown/parse
+      (->> (->hiccup (assoc default-hiccup-renderers
+                            :toc (fn [ctx {:as node :keys [title children]}]
+                                   (cond-> [:div.toc]
+                                     title (conj [:span.title title])
+                                     (seq children) (conj (into [:ul] (map (partial ->hiccup ctx)) children)))))))))
 
 (def default-hiccup-renderers
   {:doc (partial into-markup [:div])
@@ -58,7 +68,7 @@
    :text (fn [_ {:keys [text]}] text)
    :hashtag (fn [_ {:keys [text]}] [:a.tag {:href (str "/tags/" text)} (str "#" text)]) ;; TODO: make it configurable
    :blockquote (partial into-markup [:blockquote])
-   :ruler (partial into-markup [:hr])
+   :ruler (constantly [:hr])
 
    ;; images
    :image (fn [{:as ctx ::keys [parent]} {:as node :keys [attrs]}]

--- a/modules/markdown/src/nextjournal/markdown/transform.cljc
+++ b/modules/markdown/src/nextjournal/markdown/transform.cljc
@@ -31,10 +31,10 @@
                         (keep (partial ->hiccup (assoc ctx ::parent node)))
                         content)))
 
-(defn toc->hiccup [{:as ctx ::keys [parent]} {:as node :keys [title content children]}]
+(defn toc->hiccup [{:as ctx ::keys [parent]} {:as node :keys [content children]}]
   (let [toc-item (cond-> [:div]
-                   (and title (seq content))
-                   (conj (let [id (->id title)]
+                   (seq content)
+                   (conj (let [id (-> node ->text ->id)]
                            [:a {:href (str "#" id) #?@(:cljs [:on-click #(when-some [el (.getElementById js/document id)] (.preventDefault %) (.scrollIntoViewIfNeeded el))])}
                             (-> node heading-markup (into-markup ctx node))]))
                    (seq children)
@@ -58,9 +58,9 @@ a paragraph
       ;; :toc
       ;; ->hiccup #_
       (->> (->hiccup (assoc default-hiccup-renderers
-                            :toc (fn [ctx {:as node :keys [title children]}]
-                                   (cond-> [:div.toc]
-                                     title (conj [:span.title title])
+                            :toc (fn [ctx {:as node :keys [content children heading-level]}]
+                                   (cond-> [:div]
+                                     (seq content) (conj [:span.title {:data-level heading-level} (-> node ->text ->id)])
                                      (seq children) (conj (into [:ul] (map (partial ->hiccup ctx)) children)))))))))
 
 (def default-hiccup-renderers

--- a/modules/markdown/test/nextjournal/markdown_test.clj
+++ b/modules/markdown/test/nextjournal/markdown_test.clj
@@ -22,7 +22,8 @@ $$\\int_a^bf(t)dt$$
 
 (deftest parse-test
   (testing "ingests markdown returns nested nodes"
-    (is (= {:content [{:content [{:text "Hello"
+    (is (= {:type :doc
+            :content [{:content [{:text "Hello"
                                   :type :text}]
                        :heading-level 1
                        :type :heading}
@@ -69,10 +70,8 @@ $$\\int_a^bf(t)dt$$
                               :heading-level 1
                               :path [:content
                                      0]
-                              :title "Hello"
-                              :type :toc}]
-                  :type :toc}
-            :type :doc}
+                              :title "Hello"}]
+                  :type :toc}}
            (md/parse markdown-text)))))
 
 (deftest ->hiccup-test
@@ -106,7 +105,7 @@ $$\\int_a^bf(t)dt$$
              "two"]]]]
          (md/->hiccup markdown-text))))
 
-
+;;(ns-unmap *ns* '->hiccup-toc-test)
 (deftest ->hiccup-toc-test
   "Builds Toc"
 
@@ -123,7 +122,8 @@ $$\\int_a^bf(t)dt$$
         data (md/parse md)
         hiccup (md.transform/->hiccup data)]
 
-    (is (= {:content [{:content [{:text "Title"
+    (is (= {:type :doc
+            :content [{:content [{:text "Title"
                                   :type :text}]
                        :heading-level 1
                        :type :heading}
@@ -140,36 +140,27 @@ $$\\int_a^bf(t)dt$$
                                   :type :text}]
                        :heading-level 3
                        :type :heading}]
-            :toc {:children [{:children [{:content [{:text "Section 1"
+            :toc {:type :toc
+                  :children [{:children [{:content [{:text "Section 1"
                                                      :type :text}]
                                           :heading-level 2
-                                          :path [:content
-                                                 1]
-                                          :title "Section 1"
-                                          :type :toc}
+                                          :path [:content 1]
+                                          :title "Section 1"}
                                          {:children [{:content [{:text "Section 2.1"
                                                                  :type :text}]
                                                       :heading-level 3
-                                                      :path [:content
-                                                             4]
-                                                      :title "Section 2.1"
-                                                      :type :toc}]
+                                                      :path [:content 4]
+                                                      :title "Section 2.1"}]
                                           :content [{:text "Section 2"
                                                      :type :text}]
                                           :heading-level 2
-                                          :path [:content
-                                                 3]
-                                          :title "Section 2"
-                                          :type :toc}]
+                                          :path [:content 3]
+                                          :title "Section 2"}]
                               :content [{:text "Title"
                                          :type :text}]
                               :heading-level 1
-                              :path [:content
-                                     0]
-                              :title "Title"
-                              :type :toc}]
-                  :type :toc}
-            :type :doc}
+                              :path [:content 0]
+                              :title "Title"}]}}
            data))
 
     (is (= [:div
@@ -214,7 +205,7 @@ $$\\int_a^bf(t)dt$$
             [:h3
              {:id "Section%202.1"}
              "Section 2.1"]]
-          hiccup))))
+           hiccup))))
 
 (deftest todo-lists
   (testing "todo lists"
@@ -263,14 +254,13 @@ $$\\int_a^bf(t)dt$$
                                  {:text " tags"
                                   :type :text}]
                        :type :paragraph}]
-            :toc {:children [{:content [{:text "Hello Tags"
+            :toc {:type :toc
+                  :children [{:content [{:text "Hello Tags"
                                          :type :text}]
                               :heading-level 1
                               :path [:content
                                      0]
-                              :title "Hello Tags"
-                              :type :toc}]
-                  :type :toc}
+                              :title "Hello Tags"}]}
             :type :doc}
            (md/parse "# Hello Tags
 par with #really_nice #useful-123 tags

--- a/modules/markdown/test/nextjournal/markdown_test.clj
+++ b/modules/markdown/test/nextjournal/markdown_test.clj
@@ -64,13 +64,13 @@ $$\\int_a^bf(t)dt$$
                                              :type :paragraph}]
                                   :type :list-item}]
                        :type :bullet-list}]
-            :toc {:content [{:level 1
-                             :node {:content [{:text "Hello" :type :text}]
-                                    :heading-level 1
-                                    :type :heading}
-                             :path [:content 0]
-                             :title "Hello"
-                             :type :toc}]
+            :toc {:children [{:content [{:text "Hello"
+                                         :type :text}]
+                              :heading-level 1
+                              :path [:content
+                                     0]
+                              :title "Hello"
+                              :type :toc}]
                   :type :toc}
             :type :doc}
            (md/parse markdown-text)))))
@@ -140,42 +140,34 @@ $$\\int_a^bf(t)dt$$
                                   :type :text}]
                        :heading-level 3
                        :type :heading}]
-            :toc {:content [{:content [{:level 2
-                                        :node {:content [{:text "Section 1"
-                                                          :type :text}]
-                                               :heading-level 2
-                                               :type :heading}
-                                        :path [:content
-                                               1]
-                                        :title "Section 1"
-                                        :type :toc}
-                                       {:content [{:level 3
-                                                   :node {:content [{:text "Section 2.1"
-                                                                     :type :text}]
-                                                          :heading-level 3
-                                                          :type :heading}
-                                                   :path [:content
-                                                          4]
-                                                   :title "Section 2.1"
-                                                   :type :toc}]
-                                        :level 2
-                                        :node {:content [{:text "Section 2"
-                                                          :type :text}]
-                                               :heading-level 2
-                                               :type :heading}
-                                        :path [:content
-                                               3]
-                                        :title "Section 2"
-                                        :type :toc}]
-                             :level 1
-                             :node {:content [{:text "Title"
-                                               :type :text}]
-                                    :heading-level 1
-                                    :type :heading}
-                             :path [:content
-                                    0]
-                             :title "Title"
-                             :type :toc}]
+            :toc {:children [{:children [{:content [{:text "Section 1"
+                                                     :type :text}]
+                                          :heading-level 2
+                                          :path [:content
+                                                 1]
+                                          :title "Section 1"
+                                          :type :toc}
+                                         {:children [{:content [{:text "Section 2.1"
+                                                                 :type :text}]
+                                                      :heading-level 3
+                                                      :path [:content
+                                                             4]
+                                                      :title "Section 2.1"
+                                                      :type :toc}]
+                                          :content [{:text "Section 2"
+                                                     :type :text}]
+                                          :heading-level 2
+                                          :path [:content
+                                                 3]
+                                          :title "Section 2"
+                                          :type :toc}]
+                              :content [{:text "Title"
+                                         :type :text}]
+                              :heading-level 1
+                              :path [:content
+                                     0]
+                              :title "Title"
+                              :type :toc}]
                   :type :toc}
             :type :doc}
            data))
@@ -189,7 +181,6 @@ $$\\int_a^bf(t)dt$$
              "Section 1"]
             [:div.toc
              [:div
-              nil
               [:ul
                [:li.toc-item
                 [:div
@@ -203,8 +194,7 @@ $$\\int_a^bf(t)dt$$
                     [:a
                      {:href "#Section%201"}
                      [:h2
-                      "Section 1"]]
-                    nil]]
+                      "Section 1"]]]]
                   [:li.toc-item
                    [:div
                     [:a
@@ -217,8 +207,7 @@ $$\\int_a^bf(t)dt$$
                        [:a
                         {:href "#Section%202.1"}
                         [:h3
-                         "Section 2.1"]]
-                       nil]]]]]]]]]]]
+                         "Section 2.1"]]]]]]]]]]]]]
             [:h2
              {:id "Section%202"}
              "Section 2"]
@@ -274,15 +263,13 @@ $$\\int_a^bf(t)dt$$
                                  {:text " tags"
                                   :type :text}]
                        :type :paragraph}]
-            :toc {:content [{:level 1
-                             :node {:content [{:text "Hello Tags"
-                                               :type :text}]
-                                    :heading-level 1
-                                    :type :heading}
-                             :path [:content
-                                    0]
-                             :title "Hello Tags"
-                             :type :toc}]
+            :toc {:children [{:content [{:text "Hello Tags"
+                                         :type :text}]
+                              :heading-level 1
+                              :path [:content
+                                     0]
+                              :title "Hello Tags"
+                              :type :toc}]
                   :type :toc}
             :type :doc}
            (md/parse "# Hello Tags

--- a/modules/markdown/test/nextjournal/markdown_test.clj
+++ b/modules/markdown/test/nextjournal/markdown_test.clj
@@ -23,6 +23,7 @@ $$\\int_a^bf(t)dt$$
 (deftest parse-test
   (testing "ingests markdown returns nested nodes"
     (is (= {:type :doc
+            :title "Hello"
             :content [{:content [{:text "Hello"
                                   :type :text}]
                        :heading-level 1
@@ -105,7 +106,14 @@ $$\\int_a^bf(t)dt$$
              "two"]]]]
          (md/->hiccup markdown-text))))
 
-;;(ns-unmap *ns* '->hiccup-toc-test)
+(deftest set-title-when-missing
+  (testing "sets title in document structure to the first heading of whatever level"
+    (is (= "and some title"
+           (:title (md/parse "- One
+- Two
+## and some title
+### this is not a title" ))))))
+
 (deftest ->hiccup-toc-test
   "Builds Toc"
 
@@ -123,6 +131,7 @@ $$\\int_a^bf(t)dt$$
         hiccup (md.transform/->hiccup data)]
 
     (is (= {:type :doc
+            :title "Title"
             :content [{:content [{:text "Title"
                                   :type :text}]
                        :heading-level 1
@@ -239,7 +248,9 @@ $$\\int_a^bf(t)dt$$
 
 (deftest tags-text
   (testing "parsing tags"
-    (is (= {:content [{:content [{:text "Hello Tags"
+    (is (= {:type :doc
+            :title "Hello Tags"
+            :content [{:content [{:text "Hello Tags"
                                   :type :text}]
                        :heading-level 1
                        :type :heading}
@@ -260,8 +271,7 @@ $$\\int_a^bf(t)dt$$
                               :heading-level 1
                               :path [:content
                                      0]
-                              :title "Hello Tags"}]}
-            :type :doc}
+                              :title "Hello Tags"}]}}
            (md/parse "# Hello Tags
 par with #really_nice #useful-123 tags
 "))))

--- a/modules/markdown/test/nextjournal/markdown_test.clj
+++ b/modules/markdown/test/nextjournal/markdown_test.clj
@@ -69,9 +69,7 @@ $$\\int_a^bf(t)dt$$
             :toc {:children [{:content [{:text "Hello"
                                          :type :text}]
                               :heading-level 1
-                              :path [:content
-                                     0]
-                              :title "Hello"
+                              :path [:content 0]
                               :type :toc}]
                   :type :toc}}
            (md/parse markdown-text)))))
@@ -153,30 +151,22 @@ $$\\int_a^bf(t)dt$$
             :toc {:children [{:children [{:content [{:text "Section 1"
                                                      :type :text}]
                                           :heading-level 2
-                                          :path [:content
-                                                 1]
-                                          :title "Section 1"
+                                          :path [:content 1]
                                           :type :toc}
                                          {:children [{:content [{:text "Section 2.1"
                                                                  :type :text}]
                                                       :heading-level 3
-                                                      :path [:content
-                                                             4]
-                                                      :title "Section 2.1"
+                                                      :path [:content 4]
                                                       :type :toc}]
                                           :content [{:text "Section 2"
                                                      :type :text}]
                                           :heading-level 2
-                                          :path [:content
-                                                 3]
-                                          :title "Section 2"
+                                          :path [:content 3]
                                           :type :toc}]
                               :content [{:text "Title"
                                          :type :text}]
                               :heading-level 1
-                              :path [:content
-                                     0]
-                              :title "Title"
+                              :path [:content 0]
                               :type :toc}]
                   :type :toc}}
            data))
@@ -276,7 +266,6 @@ $$\\int_a^bf(t)dt$$
                        :type :paragraph}]
             :toc {:type :toc
                   :children [{:type :toc
-                              :title "Hello Tags"
                               :content [{:text "Hello Tags"
                                          :type :text}]
                               :heading-level 1

--- a/modules/markdown/test/nextjournal/markdown_test.clj
+++ b/modules/markdown/test/nextjournal/markdown_test.clj
@@ -71,7 +71,8 @@ $$\\int_a^bf(t)dt$$
                               :heading-level 1
                               :path [:content
                                      0]
-                              :title "Hello"}]
+                              :title "Hello"
+                              :type :toc}]
                   :type :toc}}
            (md/parse markdown-text)))))
 
@@ -149,27 +150,35 @@ $$\\int_a^bf(t)dt$$
                                   :type :text}]
                        :heading-level 3
                        :type :heading}]
-            :toc {:type :toc
-                  :children [{:children [{:content [{:text "Section 1"
+            :toc {:children [{:children [{:content [{:text "Section 1"
                                                      :type :text}]
                                           :heading-level 2
-                                          :path [:content 1]
-                                          :title "Section 1"}
+                                          :path [:content
+                                                 1]
+                                          :title "Section 1"
+                                          :type :toc}
                                          {:children [{:content [{:text "Section 2.1"
                                                                  :type :text}]
                                                       :heading-level 3
-                                                      :path [:content 4]
-                                                      :title "Section 2.1"}]
+                                                      :path [:content
+                                                             4]
+                                                      :title "Section 2.1"
+                                                      :type :toc}]
                                           :content [{:text "Section 2"
                                                      :type :text}]
                                           :heading-level 2
-                                          :path [:content 3]
-                                          :title "Section 2"}]
+                                          :path [:content
+                                                 3]
+                                          :title "Section 2"
+                                          :type :toc}]
                               :content [{:text "Title"
                                          :type :text}]
                               :heading-level 1
-                              :path [:content 0]
-                              :title "Title"}]}}
+                              :path [:content
+                                     0]
+                              :title "Title"
+                              :type :toc}]
+                  :type :toc}}
            data))
 
     (is (= [:div
@@ -214,7 +223,7 @@ $$\\int_a^bf(t)dt$$
             [:h3
              {:id "Section%202.1"}
              "Section 2.1"]]
-           hiccup))))
+          hiccup))))
 
 (deftest todo-lists
   (testing "todo lists"
@@ -266,12 +275,12 @@ $$\\int_a^bf(t)dt$$
                                   :type :text}]
                        :type :paragraph}]
             :toc {:type :toc
-                  :children [{:content [{:text "Hello Tags"
+                  :children [{:type :toc
+                              :title "Hello Tags"
+                              :content [{:text "Hello Tags"
                                          :type :text}]
                               :heading-level 1
-                              :path [:content
-                                     0]
-                              :title "Hello Tags"}]}}
+                              :path [:content 0]}]}}
            (md/parse "# Hello Tags
 par with #really_nice #useful-123 tags
 "))))

--- a/modules/viewer/src/nextjournal/viewer/markdown.cljs
+++ b/modules/viewer/src/nextjournal/viewer/markdown.cljs
@@ -227,6 +227,32 @@ Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium dolor
 Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
 "})
 
+(dc/defcard toc-standalone
+  "Shows how to render the TOC of a document"
+  [toc]
+  [:div.viewer-markdown
+   [inspect* {:nextjournal/viewer :hiccup
+              :nextjournal/value (md.transform/->hiccup @toc)}]]
+  {::dc/state (-> "# My Document
+## Section 1
+### Section 1.1
+## Section 2
+### Section 2.1
+" md/parse :toc)})
+
+(dc/defcard toc-standalone-dropping-title
+  "Shows how to drop top h1 entry from TOC"
+  [toc]
+  [:div.viewer-markdown
+   [inspect* {:nextjournal/viewer :hiccup
+              :nextjournal/value (md.transform/->hiccup @toc)}]]
+  {::dc/state (-> "# My Document
+## Section 1
+### Section 1.1
+## Section 2
+### Section 2.1
+" md/parse :toc :children first (dissoc :content))})
+
 (dc/defcard reference
   [markdown]
   [:div.viewer-markdown

--- a/resources/css/viewer.css
+++ b/resources/css/viewer.css
@@ -111,6 +111,12 @@
   @apply mt-1;
 }
 
+/* compact TOC */
+.viewer-markdown .toc ul {
+  list-style: none;
+  @apply my-0;
+}
+
 /* Code Viewer */
 /* --------------------------------------------------------------- */
 


### PR DESCRIPTION
* simplifies structure of `:toc` in the result of parse
* adds document `:title` (the text of the first heading) to result of parse
* adds devcards to show how to render TOC outside of the document flow
* removes the class `.not-prose` from `ui.devcards/show-card` as that is conflicting with devcards for the markdown viewer.