### PR TITLE
Lock markdown parsing + file->doc start/stop print logging

### DIFF
--- a/modules/devdocs/src/nextjournal/devdocs.clj
+++ b/modules/devdocs/src/nextjournal/devdocs.clj
@@ -78,19 +78,23 @@
                                _ (when (not exists?)
                                    (println "WARN: Devdoc devdoc not found: " path))]
                          :when exists?]
-                     (let [{:keys [toc title edn-doc]} (file->doc path opts)
-                           devdoc-id (or slug (slugify (or title (path->slug path))))
-                           title (or title (-> devdoc-id (str/replace #"[-_]" " ") str/capitalize))]
-                       `{:id ~devdoc-id
-                         :toc ~toc
-                         :title ~title
-                         :path ~path
-                         :collection-id ~collection-id
-                         :file-size ~(.length file)
-                         :last-modified ~(let [ts (str/trim (:out (sh/sh "git" "log" "-1" "--format=%ct" path)))]
-                                           (when (not= "" ts)
-                                             (* (Long/parseLong ts) 1000)))
-                         :edn-doc ~edn-doc})))})))
+                     (do
+                       (println "started building doc for " path)
+                       (let [{:keys [time-ms result]} (clerk/time-ms (file->doc path opts))
+                             {:keys [toc title edn-doc]} result
+                             devdoc-id (or slug (slugify (or title (path->slug path))))
+                             title (or title (-> devdoc-id (str/replace #"[-_]" " ") str/capitalize))]
+                         (println "finished building doc for " path " [" time-ms "ms]")
+                         `{:id ~devdoc-id
+                           :toc ~toc
+                           :title ~title
+                           :path ~path
+                           :collection-id ~collection-id
+                           :file-size ~(.length file)
+                           :last-modified ~(let [ts (str/trim (:out (sh/sh "git" "log" "-1" "--format=%ct" path)))]
+                                             (when (not= "" ts)
+                                               (* (Long/parseLong ts) 1000)))
+                           :edn-doc ~edn-doc}))))})))
 
 (defmacro only-on-ci
   "Only include the wrapped form in the build output if CI=true."

--- a/modules/devdocs/src/nextjournal/devdocs.clj
+++ b/modules/devdocs/src/nextjournal/devdocs.clj
@@ -53,12 +53,6 @@
 #_(file->doc "docs/clerk.clj" {})
 #_(file->doc "docs/frontend.md" {:eval? false})
 
-(defn total-memory [obj]
-  (let [baos (java.io.ByteArrayOutputStream.)]
-    (with-open [oos (java.io.ObjectOutputStream. baos)]
-      (.writeObject oos obj))
-    (count (.toByteArray baos))))
-
 (defmacro defcollection
   "Create a Devdoc Collection out of a set of Markdown documents
 
@@ -92,7 +86,7 @@
                              {:keys [toc title edn-doc]} result
                              devdoc-id (or slug (slugify (or title (path->slug path))))
                              title (or title (-> devdoc-id (str/replace #"[-_]" " ") str/capitalize))]
-                         (println "finished building doc for " path " {:seconds " (/ time-ms 1000) ", :bytes " (total-memory edn-doc) "}")
+                         (println "finished building doc for " path " {:seconds " (/ time-ms 1000) ", :EDN-size " (count edn-doc) "}")
                          `{:id ~devdoc-id
                            :toc ~toc
                            :title ~title

--- a/modules/markdown/src/nextjournal/markdown.clj
+++ b/modules/markdown/src/nextjournal/markdown.clj
@@ -36,7 +36,9 @@
 
 (defn make-js-fn [fn-name]
   (let [f (.getMember MD-imports fn-name)]
-    (fn [& args] (.execute f (to-array args)))))
+    (fn [& args]
+      (locking MD-imports
+        (.execute f (to-array args))))))
 
 (def parse* (make-js-fn "parseJ"))
 

--- a/modules/markdown/src/nextjournal/markdown.clj
+++ b/modules/markdown/src/nextjournal/markdown.clj
@@ -37,8 +37,7 @@
 (defn make-js-fn [fn-name]
   (let [f (.getMember MD-imports fn-name)]
     (fn [& args]
-      (locking MD-imports
-        (.execute f (to-array args))))))
+      (.execute f (to-array args)))))
 
 (def parse* (make-js-fn "parseJ"))
 


### PR DESCRIPTION
if two threads try to parse markdown or do clerk namespace effects/switches at the same time we get exceptions. Either graaljs polyglot exceptions or namespace imports not existing. This PR adds a lock around the whole clerk usage to sequentialize and hence prevent such exceptions

also log when a document parsing for a file starts and stops, how long it took, and how big the generated output is.