### PR TITLE
fix duplicate editors on cljs reload

### DIFF
--- a/modules/viewer/src/nextjournal/viewer/code.cljs
+++ b/modules/viewer/src/nextjournal/viewer/code.cljs
@@ -33,15 +33,15 @@
               cm6-theme])
 
 (defn viewer* [value]
+  ^{:key value}
   [:div {:ref #(when %
                  ;; remove previous editor-view, if it exists
                  (some-> (j/get % :editorView)
                          (j/call :destroy))
-
+                 ;; create new editor-view & attach to DOM element so we can destroy it above
                  (j/assoc! % :editorView
                            (EditorView. #js {:state (.create EditorState #js {:doc value :extensions ext})
                                              :parent %})))}])
 
 (defn viewer [value]
-  ^{:nextjournal/viewer :reagent
-    :key value} [viewer* value])
+  ^{:nextjournal/viewer :reagent} [viewer* value])

--- a/modules/viewer/src/nextjournal/viewer/code.cljs
+++ b/modules/viewer/src/nextjournal/viewer/code.cljs
@@ -35,13 +35,13 @@
 (defn viewer* [value]
   ^{:key value}
   [:div {:ref #(when %
-                 ;; remove previous editor-view, if it exists
-                 (some-> (j/get % :editorView)
-                         (j/call :destroy))
-                 ;; create new editor-view & attach to DOM element so we can destroy it above
-                 (j/assoc! % :editorView
-                           (EditorView. #js {:state (.create EditorState #js {:doc value :extensions ext})
-                                             :parent %})))}])
+                 (let [prev-view (j/get % :editorView)]
+                   (when (or (nil? prev-view)
+                             (not= value (j/call-in prev-view [:state :doc :toString])))
+                     (some-> prev-view (j/call :destroy))
+                     (j/assoc! % :editorView
+                               (EditorView. #js {:state (.create EditorState #js {:doc value :extensions ext})
+                                                 :parent %})))))}])
 
 (defn viewer [value]
   ^{:nextjournal/viewer :reagent} [viewer* value])

--- a/modules/viewer/src/nextjournal/viewer/code.cljs
+++ b/modules/viewer/src/nextjournal/viewer/code.cljs
@@ -33,10 +33,15 @@
               cm6-theme])
 
 (defn viewer* [value]
-  ^{:key value}
   [:div {:ref #(when %
-                 (EditorView. #js {:state (.create EditorState #js {:doc value :extensions ext})
-                                   :parent %}))}])
+                 ;; remove previous editor-view, if it exists
+                 (some-> (j/get % :editorView)
+                         (j/call :destroy))
+
+                 (j/assoc! % :editorView
+                           (EditorView. #js {:state (.create EditorState #js {:doc value :extensions ext})
+                                             :parent %})))}])
 
 (defn viewer [value]
-  ^{:nextjournal/viewer :reagent} [viewer* value])
+  ^{:nextjournal/viewer :reagent
+    :key value} [viewer* value])


### PR DESCRIPTION
Issue: when a Clerk notebook containing code editors reloads (due to cljs recompilation), code blocks are duplicated because new CodeMirror 6 instances are created on the existing DOM elements without cleaning up the old ones.

This PR fixes the issue by making our EditorView instances readable from the view's DOM node, so we can destroy stale instances when necessary.