### PR TITLE
Disable line wrapping extension in code viewer

### DIFF
--- a/modules/viewer/deps.edn
+++ b/modules/viewer/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src"]
- :deps  {io.github.nextjournal/clojure-mode {:git/sha "56d084a44d188bfc9e9d8cf3aedb5f097508f8a4"}
+ :deps  {io.github.nextjournal/clojure-mode {:git/sha "699a445ebf2767f41fd0b6eeed5a008511702be6"}
          io.github.nextjournal/cljs-extensions {:local/root "../cljs-extensions"}
          io.github.nextjournal/markdown        {:local/root "../markdown"}
          io.github.nextjournal/log             {:local/root "../log"}

--- a/modules/viewer/deps.edn
+++ b/modules/viewer/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src"]
- :deps  {io.github.nextjournal/clojure-mode {:git/sha "a83c87cd2bd2049b70613f360336a096d15c5518"}
+ :deps  {io.github.nextjournal/clojure-mode {:git/sha "56d084a44d188bfc9e9d8cf3aedb5f097508f8a4"}
          io.github.nextjournal/cljs-extensions {:local/root "../cljs-extensions"}
          io.github.nextjournal/markdown        {:local/root "../markdown"}
          io.github.nextjournal/log             {:local/root "../log"}

--- a/modules/viewer/src/nextjournal/viewer.cljs
+++ b/modules/viewer/src/nextjournal/viewer.cljs
@@ -616,21 +616,20 @@
   (let [{:keys [clj clj-map js]} @state]
     [:<>
      [:div
-      [:div.flex.flex-col.items-center.viewer-notebook
-       (into [:div]
-             (map-indexed (fn [i example]
-                            [:div.viewer.viewer-code
-                             [:div.text-slate-400.mb-1
-                              {:class "text-[11px]"}
-                              [:strong "Example " (inc i)]]
-                             [code/viewer example]])
-                          @state))]]
+      (into [:div.flex.flex-col.items-center.viewer-notebook]
+            (map-indexed (fn [i example]
+                           [:div.viewer.viewer-code.w-full.max-w-wide.not-prose
+                            [:div.text-slate-400.mb-1
+                             {:class "text-[11px]"}
+                             [:strong "Example " (inc i)]]
+                            [code/viewer example]])
+                         @state))]
      [:div.dark
       [:div.dark:bg-slate-900
        [:div.flex.flex-col.items-center.viewer-notebook
         (into [:div]
               (map-indexed (fn [i example]
-                             [:div.viewer.viewer-code
+                             [:div.viewer.viewer-code.w-full.max-w-wide
                               [:div.text-slate-400.mb-1
                                {:class "text-[11px]"}
                                [:strong "Example " (inc i)]]


### PR DESCRIPTION
And let CodeMirror infer it from the line-wrapping property on the target element instead.