### PR TITLE
Iframe Devcards with device frame

### DIFF
--- a/modules/devcards/src/nextjournal/devcards/routes.cljs
+++ b/modules/devcards/src/nextjournal/devcards/routes.cljs
@@ -22,7 +22,8 @@
 (def routes
   [["/" {:name :devcards/root :view devcards-ui/root}]
    ["/:ns" {:name :devcards/by-namespace :view devcards-ui/by-namespace}]
-   ["/:ns/:name" {:name :devcards/by-name :view devcards-ui/by-name}]])
+   ["/:ns/:name" {:name :devcards/by-name :view devcards-ui/by-name}]
+   ["/_iframe/:ns/:name" {:name :devcards/iframe-by-name :view devcards-ui/iframe-by-name}]])
 
 (defn navigate-to
   "Navigate to the given path, then trigger routing."

--- a/modules/devcards/src/nextjournal/devcards_ui.cljs
+++ b/modules/devcards/src/nextjournal/devcards_ui.cljs
@@ -146,7 +146,7 @@
 (defn extract-opts [data]
   (select-keys data dc-opts))
 
-(v/defview show-iframe* [{card ::v/props ::v/keys [state] :keys [main initial-db initial-state loading-data?]}]
+(v/defview show-iframe* [{card ::v/props :keys [main initial-db initial-state loading-data?]}]
   (when card
     (if loading-data?
       "Loading data..."
@@ -155,7 +155,7 @@
                                (reset! (:app-db (rf/current-frame)) initial-db))]
           (let [main (main)
                 main (if (fn? main)
-                       [main state]
+                       [main (reagent/atom initial-state)]
                        main)]
             [nextjournal.devcards/error-boundary
              [:div main]]))))))


### PR DESCRIPTION
You can now provide `::dc/device :iphone` in card options to render the devcard inside an iframe that looks like an iPhone.